### PR TITLE
Include untracked files when using --unstaged; Add --diff argument to define a custom range

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ If you haven't staged your changes yet (with `git add`), you can use the `--unst
 cmai --unstaged --message-only
 ```
 
-This will generate a message based on your current changes in the working tree without staging them.
+This will generate a message based on your current unstaged and untracked working tree changes without staging them first.
 
 ### Generate Branch Name Only
 
@@ -248,7 +248,7 @@ Options:
   --push, -p            Push changes after commit
   --message-only        Generate message only, no git add/commit/push
   --branch-name-only    Generate branch name only, no git add/commit/push
-  --unstaged            Use unstaged changes for diff
+  --unstaged            Use unstaged and untracked changes for diff
   --diff <diff>         Use a custom git diff target for message/branch-only
   --model <model>       Use specific model (default: google/gemini-flash-1.5-8b)
   --use-ollama          Use Ollama as provider (saves for future use)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ cmai --message-only
 
 This is useful if you want to review the message before committing.
 
+You can also base this on a specific diff target:
+
+```bash
+cmai --message-only --diff main...HEAD
+```
+
 ### Use Unstaged Changes
 
 If you haven't staged your changes yet (with `git add`), you can use the `--unstaged` flag:
@@ -226,6 +232,12 @@ cmai --branch-name-only
 
 This will output a branch name like `fix/api-error-handling` or `feat/new-login-page` based on the context of your changes. It does not perform any git operations.
 
+You can also base this on a specific diff target:
+
+```bash
+cmai --branch-name-only --diff HEAD~1..HEAD
+```
+
 ## Command Line Options
 
 ```bash
@@ -237,6 +249,7 @@ Options:
   --message-only        Generate message only, no git add/commit/push
   --branch-name-only    Generate branch name only, no git add/commit/push
   --unstaged            Use unstaged changes for diff
+  --diff <diff>         Use a custom git diff target for message/branch-only
   --model <model>       Use specific model (default: google/gemini-flash-1.5-8b)
   --use-ollama          Use Ollama as provider (saves for future use)
   --use-lmstudio        Use LMStudio as provider (saves for future use)

--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ Options:
   --unstaged            Use unstaged and untracked changes for diff
   --diff <diff>         Use a custom git diff target for message/branch-only
   --model <model>       Use specific model (default: google/gemini-flash-1.5-8b)
+  --temperature <n>     Set sampling temperature (0-2; saves for future use)
+  --top-p <n>           Set nucleus sampling probability (0-1; saves for future use)
+  --top-k <n>           Set top-k sampling count (non-negative integer)
+  --presence-penalty <n>  Set presence penalty (-2 to 2; saves for future use)
+  --max-tokens <n>      Set maximum generated tokens (saves for future use)
+  --reasoning-effort <level>  Set none/minimal/low/medium/high/xhigh/max
+  --extra-body <json>   Merge arbitrary JSON object into request body
+  --reset-generation-options  Clear saved generation options
   --use-ollama          Use Ollama as provider (saves for future use)
   --use-lmstudio        Use LMStudio as provider (saves for future use)
   --use-openrouter      Use OpenRouter as provider (saves for future use)
@@ -336,7 +344,24 @@ cmai --base-url https://api.example.com/v1
 
 # Combine multiple flags
 cmai --debug --push --model your-model --base-url https://api.example.com/v1
+
+# Configure generation and pass provider-specific request fields
+cmai --temperature 0.7 --top-p 0.8 --top-k 40 \
+  --presence-penalty -0.2 --max-tokens 32768 \
+  --extra-body '{"chat_template_kwargs":{"enable_thinking":false}}'
+
+# Configure reasoning effort for a supported model
+cmai --reasoning-effort high
 ```
+
+Generation options persist across runs. OpenRouter receives `reasoning.effort`;
+LM Studio and custom OpenAI-compatible providers receive `reasoning_effort`.
+`--extra-body` accepts any JSON object and merges it last into the raw HTTP
+request, matching the Python SDK's `extra_body` behavior. Extra fields can add
+provider-specific controls or override generated top-level fields. Ollama maps
+generation controls into `options`, including `top_k`, `presence_penalty`, and
+`num_predict` for maximum tokens, before applying the extra body.
+Use `--reset-generation-options` to omit all saved generation controls again.
 
 Example generated commit messages:
 - `feat(api): add user authentication system`
@@ -357,9 +382,14 @@ Example generated commit messages:
 │   ├── config       # API key
 │   ├── model        # Selected AI model
 │   ├── provider     # Selected provider (openrouter/ollama/custom)
-│   └── base_url     # API base URL
-│   ├── model
-│   └── base_url
+│   ├── base_url     # API base URL
+│   ├── temperature  # Sampling temperature (optional)
+│   ├── top_p        # Nucleus sampling probability (optional)
+│   ├── top_k        # Top-k sampling count (optional)
+│   ├── presence_penalty # Presence penalty (optional)
+│   ├── max_tokens   # Maximum generated tokens (optional)
+│   ├── reasoning_effort # Reasoning level (optional)
+│   └── extra_body    # Arbitrary request JSON fields (optional)
 └── usr/
   └── local/
     └── bin/

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ This is useful if you want to review the message before committing.
 Diff context is capped from the configured model context window. CMAI defaults
 to 131,072 context tokens, reserves 4,096 output tokens when no output limit is
 set, keeps a 10% safety margin, and uses a conservative byte-based estimate.
-For larger changes, CMAI keeps the file list and truncates the diff.
+For larger changes, CMAI keeps the file list and truncates the diff at a
+complete line boundary.
 `--max-context-tokens` only controls prompt budgeting; it is not sent to the
 provider. When `--max-output-tokens` is omitted, the 4,096-token reserve only
 affects budgeting and no output limit is sent.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Options:
   --max-tokens <n>      Set maximum generated tokens (saves for future use)
   --reasoning-effort <level>  Set none/minimal/low/medium/high/xhigh/max
   --extra-body <json>   Merge arbitrary JSON object into request body
-  --reset-generation-options  Clear saved generation options
+  --clear-model-options  Clear saved model options
   --use-ollama          Use Ollama as provider (saves for future use)
   --use-lmstudio        Use LMStudio as provider (saves for future use)
   --use-openrouter      Use OpenRouter as provider (saves for future use)
@@ -356,12 +356,18 @@ cmai --reasoning-effort high
 
 Generation options persist across runs. OpenRouter receives `reasoning.effort`;
 LM Studio and custom OpenAI-compatible providers receive `reasoning_effort`.
+Supported effort levels depend on the selected model. OpenRouter accepts the
+full listed set, including `none`; `none` is sent explicitly so it disables
+reasoning instead of selecting the model default. For Ollama, only GPT-OSS
+models accept effort levels (`low`, `medium`, or `high`) and cannot use `none`.
+Other Ollama models accept `--reasoning-effort none` as `"think": false`; use
+`--extra-body '{"think":true}'` to enable their boolean thinking mode.
 `--extra-body` accepts any JSON object and merges it last into the raw HTTP
 request, matching the Python SDK's `extra_body` behavior. Extra fields can add
 provider-specific controls or override generated top-level fields. Ollama maps
 generation controls into `options`, including `top_k`, `presence_penalty`, and
 `num_predict` for maximum tokens, before applying the extra body.
-Use `--reset-generation-options` to omit all saved generation controls again.
+Use `--clear-model-options` to omit all saved model controls again.
 
 Example generated commit messages:
 - `feat(api): add user authentication system`

--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ cmai --message-only
 
 This is useful if you want to review the message before committing.
 
+Diff context is capped from the configured model context window. CMAI defaults
+to 131,072 context tokens, reserves 4,096 output tokens when no output limit is
+set, keeps a 10% safety margin, and uses a conservative byte-based estimate.
+For larger changes, CMAI keeps the file list and truncates the diff.
+`--max-context-tokens` only controls prompt budgeting; it is not sent to the
+provider. When `--max-output-tokens` is omitted, the 4,096-token reserve only
+affects budgeting and no output limit is sent.
+
 You can also base this on a specific diff target:
 
 ```bash
@@ -255,7 +263,8 @@ Options:
   --top-p <n>           Set nucleus sampling probability (0-1; saves for future use)
   --top-k <n>           Set top-k sampling count (non-negative integer)
   --presence-penalty <n>  Set presence penalty (-2 to 2; saves for future use)
-  --max-tokens <n>      Set maximum generated tokens (saves for future use)
+  --max-output-tokens <n>  Set maximum generated tokens (saves for future use)
+  --max-context-tokens <n> Set model context window (default: 131072)
   --reasoning-effort <level>  Set none/minimal/low/medium/high/xhigh/max
   --extra-body <json>   Merge arbitrary JSON object into request body
   --clear-model-options  Clear saved model options
@@ -347,7 +356,8 @@ cmai --debug --push --model your-model --base-url https://api.example.com/v1
 
 # Configure generation and pass provider-specific request fields
 cmai --temperature 0.7 --top-p 0.8 --top-k 40 \
-  --presence-penalty -0.2 --max-tokens 32768 \
+  --presence-penalty -0.2 --max-output-tokens 4096 \
+  --max-context-tokens 262144 \
   --extra-body '{"chat_template_kwargs":{"enable_thinking":false}}'
 
 # Configure reasoning effort for a supported model

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -358,7 +358,7 @@ fi
 # Use a single, readable format for all providers (jq will handle JSON escaping)
 DIFF_ARGS=()
 if [ -n "$DIFF_SPEC" ]; then
-    DIFF_ARGS+=("$DIFF_SPEC")
+    read -ra DIFF_ARGS <<< "$DIFF_SPEC"
 elif [ "$UNSTAGED" = false ]; then
     DIFF_ARGS+=(--cached)
 fi

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -45,6 +45,21 @@ debug_log() {
     fi
 }
 
+# Collect untracked files and represent them as added files in the prompt context.
+get_untracked_changes() {
+    local files=""
+    local diffs=""
+    local file=""
+
+    while IFS= read -r -d '' file; do
+        files+="A $file"$'\n'
+        diffs+=$(git diff --no-index -- /dev/null "$file" 2>/dev/null || true)
+        diffs+=$'\n'
+    done < <(git ls-files --others --exclude-standard -z)
+
+    printf '%s\n__CMAI_SPLIT__\n%s' "$files" "$diffs"
+}
+
 # Function to save API key
 save_api_key() {
     mkdir -p "$CONFIG_DIR"
@@ -249,7 +264,7 @@ while [[ $# -gt 0 ]]; do
         echo "  --push, -p            Push changes after commit"
         echo "  --message-only        Generate message only, no git add/commit/push"
         echo "  --branch-name-only    Generate branch name only, no git add/commit/push"
-        echo "  --unstaged            Use unstaged changes for diff"
+        echo "  --unstaged            Use unstaged and untracked changes for diff"
         echo "  --diff <diff>         Use a custom git diff target for message/branch-only"
         echo "  --model <model>       Use specific model (default: google/gemini-flash-1.5-8b)"
         echo "  --use-ollama          Use Ollama as provider (saves for future use)"
@@ -366,13 +381,28 @@ fi
 CHANGES=$(git diff --name-status "${DIFF_ARGS[@]}" | tr '\t' ' ' | sed 's/  */ /g')
 # Get git diff for context
 DIFF_CONTENT=$(git diff "${DIFF_ARGS[@]}")
+
+if [ "$UNSTAGED" = true ]; then
+    UNTRACKED_DATA=$(get_untracked_changes)
+    UNTRACKED_CHANGES=${UNTRACKED_DATA%%$'\n'__CMAI_SPLIT__*}
+    UNTRACKED_DIFF=${UNTRACKED_DATA#*__CMAI_SPLIT__$'\n'}
+
+    if [ -n "$UNTRACKED_CHANGES" ]; then
+        CHANGES="${CHANGES}${CHANGES:+$'\n'}${UNTRACKED_CHANGES%$'\n'}"
+    fi
+
+    if [ -n "$UNTRACKED_DIFF" ]; then
+        DIFF_CONTENT="${DIFF_CONTENT}${DIFF_CONTENT:+$'\n'}${UNTRACKED_DIFF%$'\n'}"
+    fi
+fi
+
 debug_log "Git changes detected" "$CHANGES"
 
 if [ -z "$CHANGES" ]; then
     if [ -n "$DIFF_SPEC" ]; then
         echo "No changes found for git diff $DIFF_SPEC."
     elif [ "$UNSTAGED" = true ]; then
-        echo "No unstaged changes found."
+        echo "No unstaged or untracked changes found."
     else
         echo "No staged changes found. Please stage your changes using 'git add' first or use --unstaged flag."
     fi

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -16,6 +16,8 @@ MESSAGE_ONLY=false
 BRANCH_NAME_ONLY=false
 # Unstaged flag
 UNSTAGED=false
+# Explicit git diff target
+DIFF_SPEC=""
 # Default providers and URLs
 PROVIDER_OPENROUTER="openrouter"
 PROVIDER_OLLAMA="ollama"
@@ -226,6 +228,15 @@ while [[ $# -gt 0 ]]; do
         UNSTAGED=true
         shift
         ;;
+    --diff)
+        if [[ -n "$2" && "$2" != -* ]]; then
+            DIFF_SPEC="$2"
+            shift 2
+        else
+            echo "Error: --diff requires a diff argument"
+            exit 1
+        fi
+        ;;
     --print-config)
         print_config
         exit 0
@@ -239,6 +250,7 @@ while [[ $# -gt 0 ]]; do
         echo "  --message-only        Generate message only, no git add/commit/push"
         echo "  --branch-name-only    Generate branch name only, no git add/commit/push"
         echo "  --unstaged            Use unstaged changes for diff"
+        echo "  --diff <diff>         Use a custom git diff target for message/branch-only"
         echo "  --model <model>       Use specific model (default: google/gemini-flash-1.5-8b)"
         echo "  --use-ollama          Use Ollama as provider (saves for future use)"
         echo "  --use-openrouter      Use OpenRouter as provider (saves for future use)"
@@ -309,6 +321,16 @@ if [ -z "$API_KEY" ] && [ "$PROVIDER" = "$PROVIDER_OPENROUTER" ]; then
     exit 1
 fi
 
+if [ -n "$DIFF_SPEC" ] && [ "$UNSTAGED" = true ]; then
+    echo "Error: --diff and --unstaged cannot be used together"
+    exit 1
+fi
+
+if [ -n "$DIFF_SPEC" ] && [ "$MESSAGE_ONLY" = false ] && [ "$BRANCH_NAME_ONLY" = false ]; then
+    echo "Error: --diff can only be used with --message-only or --branch-name-only"
+    exit 1
+fi
+
 # Set default model based on provider
 if [ "$PROVIDER" = "$PROVIDER_OLLAMA" ]; then
     [ -z "$MODEL" ] && MODEL="$OLLAMA_MODEL"
@@ -334,16 +356,22 @@ if [ "$MESSAGE_ONLY" = false ] && [ "$BRANCH_NAME_ONLY" = false ] && [ "$UNSTAGE
 fi
 
 # Use a single, readable format for all providers (jq will handle JSON escaping)
-DIFF_RANGE="--cached"
-[ "$UNSTAGED" = true ] && DIFF_RANGE=""
+DIFF_ARGS=()
+if [ -n "$DIFF_SPEC" ]; then
+    DIFF_ARGS+=("$DIFF_SPEC")
+elif [ "$UNSTAGED" = false ]; then
+    DIFF_ARGS+=(--cached)
+fi
 
-CHANGES=$(git diff $DIFF_RANGE --name-status | tr '\t' ' ' | sed 's/  */ /g')
+CHANGES=$(git diff --name-status "${DIFF_ARGS[@]}" | tr '\t' ' ' | sed 's/  */ /g')
 # Get git diff for context
-DIFF_CONTENT=$(git diff $DIFF_RANGE)
+DIFF_CONTENT=$(git diff "${DIFF_ARGS[@]}")
 debug_log "Git changes detected" "$CHANGES"
 
 if [ -z "$CHANGES" ]; then
-    if [ "$UNSTAGED" = true ]; then
+    if [ -n "$DIFF_SPEC" ]; then
+        echo "No changes found for git diff $DIFF_SPEC."
+    elif [ "$UNSTAGED" = true ]; then
         echo "No unstaged changes found."
     else
         echo "No staged changes found. Please stage your changes using 'git add' first or use --unstaged flag."

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -5,6 +5,13 @@ CONFIG_FILE="$CONFIG_DIR/config"
 MODEL_FILE="$CONFIG_DIR/model"
 BASE_URL_FILE="$CONFIG_DIR/base_url"
 PROVIDER_FILE="$CONFIG_DIR/provider"
+TEMPERATURE_FILE="$CONFIG_DIR/temperature"
+TOP_P_FILE="$CONFIG_DIR/top_p"
+TOP_K_FILE="$CONFIG_DIR/top_k"
+PRESENCE_PENALTY_FILE="$CONFIG_DIR/presence_penalty"
+MAX_TOKENS_FILE="$CONFIG_DIR/max_tokens"
+REASONING_EFFORT_FILE="$CONFIG_DIR/reasoning_effort"
+EXTRA_BODY_FILE="$CONFIG_DIR/extra_body"
 
 # Debug mode flag
 DEBUG=false
@@ -63,9 +70,82 @@ fail() {
     exit 1
 }
 
+save_setting() {
+    local file="$1"
+    local value="$2"
+
+    printf '%s\n' "$value" >"$file"
+    chmod 600 "$file"
+}
+
+get_setting() {
+    local file="$1"
+
+    if [ -f "$file" ]; then
+        cat "$file"
+    fi
+}
+
+validate_decimal_range() {
+    local value="$1"
+    local minimum="$2"
+    local maximum="$3"
+    local option="$4"
+
+    if ! [[ "$value" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] ||
+        ! awk -v value="$value" -v minimum="$minimum" -v maximum="$maximum" \
+            'BEGIN { exit !(value >= minimum && value <= maximum) }'; then
+        fail "$option must be between $minimum and $maximum"
+    fi
+}
+
+validate_positive_integer() {
+    local value="$1"
+    local option="$2"
+
+    if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+        fail "$option must be a positive integer"
+    fi
+}
+
+validate_nonnegative_integer() {
+    local value="$1"
+    local option="$2"
+
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+        fail "$option must be a non-negative integer"
+    fi
+}
+
+validate_signed_decimal_range() {
+    local value="$1"
+    local minimum="$2"
+    local maximum="$3"
+    local option="$4"
+
+    if ! [[ "$value" =~ ^-?([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] ||
+        ! awk -v value="$value" -v minimum="$minimum" -v maximum="$maximum" \
+            'BEGIN { exit !(value >= minimum && value <= maximum) }'; then
+        fail "$option must be between $minimum and $maximum"
+    fi
+}
+
+validate_reasoning_effort() {
+    case "$1" in
+    none | minimal | low | medium | high | xhigh | max) ;;
+    *) fail "--reasoning-effort must be one of: none, minimal, low, medium, high, xhigh, max" ;;
+    esac
+}
+
+validate_extra_body() {
+    if ! printf '%s' "$1" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        fail "--extra-body must be a valid JSON object"
+    fi
+}
+
 cleanup() {
     if [ -n "${TEMP_DIR:-}" ] && [ "$TEMP_DIR" != "/" ] && [ -d "$TEMP_DIR" ]; then
-        rm -f "$TEMP_DIR/prompt" "$TEMP_DIR/request.json"
+        rm -f "$TEMP_DIR/prompt" "$TEMP_DIR/request.json" "$TEMP_DIR/extra-body.json"
         rmdir "$TEMP_DIR" 2>/dev/null || true
     fi
 }
@@ -158,6 +238,17 @@ print_config() {
     echo "  Provider:  $(get_provider)"
     echo "  Base URL:  $(get_base_url)"
     echo "  Model:     $(get_model)"
+    echo "  Temperature:      ${TEMPERATURE:-Not set}"
+    echo "  Top P:            ${TOP_P:-Not set}"
+    echo "  Top K:            ${TOP_K:-Not set}"
+    echo "  Presence penalty: ${PRESENCE_PENALTY:-Not set}"
+    echo "  Max tokens:       ${MAX_TOKENS:-Not set}"
+    echo "  Reasoning effort: ${REASONING_EFFORT:-Not set}"
+    if [ -z "$EXTRA_BODY" ]; then
+        echo "  Extra body:       Not set"
+    else
+        echo "  Extra body:       Set"
+    fi
     API_KEY=$(get_api_key)
     if [ -z "$API_KEY" ]; then
         echo "  API Key:   Not set"
@@ -185,6 +276,13 @@ LMSTUDIO_MODEL="default"
 
 # Get saved model or use default based on provider
 MODEL=$(get_model)
+TEMPERATURE=$(get_setting "$TEMPERATURE_FILE")
+TOP_P=$(get_setting "$TOP_P_FILE")
+TOP_K=$(get_setting "$TOP_K_FILE")
+PRESENCE_PENALTY=$(get_setting "$PRESENCE_PENALTY_FILE")
+MAX_TOKENS=$(get_setting "$MAX_TOKENS_FILE")
+REASONING_EFFORT=$(get_setting "$REASONING_EFFORT_FILE")
+EXTRA_BODY=$(get_setting "$EXTRA_BODY_FILE")
 if [ -z "$MODEL" ]; then
     case "$PROVIDER" in
     "$PROVIDER_OLLAMA")
@@ -292,6 +390,14 @@ while [[ $# -gt 0 ]]; do
         echo "  --unstaged            Use unstaged and untracked changes for diff"
         echo "  --diff <diff>         Use a custom git diff target for message/branch-only"
         echo "  --model <model>       Use specific model (default: google/gemini-flash-1.5-8b)"
+        echo "  --temperature <n>     Set sampling temperature (0-2; saves for future use)"
+        echo "  --top-p <n>           Set nucleus sampling probability (0-1; saves for future use)"
+        echo "  --top-k <n>           Set top-k sampling count (non-negative integer)"
+        echo "  --presence-penalty <n>  Set presence penalty (-2 to 2; saves for future use)"
+        echo "  --max-tokens <n>      Set maximum generated tokens (saves for future use)"
+        echo "  --reasoning-effort <level>  Set none/minimal/low/medium/high/xhigh/max"
+        echo "  --extra-body <json>   Merge arbitrary JSON object into request body"
+        echo "  --reset-generation-options  Clear saved generation options"
         echo "  --use-ollama          Use Ollama as provider (saves for future use)"
         echo "  --use-openrouter      Use OpenRouter as provider (saves for future use)"
         echo "  --use-lmstudio        Use LMStudio as provider (saves for future use)"
@@ -320,6 +426,68 @@ while [[ $# -gt 0 ]]; do
             echo "Error: --model requires a valid model name"
             exit 1
         fi
+        ;;
+    --temperature)
+        [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--temperature requires a value"
+        validate_decimal_range "$2" 0 2 "--temperature"
+        TEMPERATURE="$2"
+        save_setting "$TEMPERATURE_FILE" "$TEMPERATURE"
+        shift 2
+        ;;
+    --top-p)
+        [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--top-p requires a value"
+        validate_decimal_range "$2" 0 1 "--top-p"
+        TOP_P="$2"
+        save_setting "$TOP_P_FILE" "$TOP_P"
+        shift 2
+        ;;
+    --top-k)
+        [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--top-k requires a value"
+        validate_nonnegative_integer "$2" "--top-k"
+        TOP_K="$2"
+        save_setting "$TOP_K_FILE" "$TOP_K"
+        shift 2
+        ;;
+    --presence-penalty)
+        [ -n "${2:-}" ] || fail "--presence-penalty requires a value"
+        validate_signed_decimal_range "$2" -2 2 "--presence-penalty"
+        PRESENCE_PENALTY="$2"
+        save_setting "$PRESENCE_PENALTY_FILE" "$PRESENCE_PENALTY"
+        shift 2
+        ;;
+    --max-tokens)
+        [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--max-tokens requires a value"
+        validate_positive_integer "$2" "--max-tokens"
+        MAX_TOKENS="$2"
+        save_setting "$MAX_TOKENS_FILE" "$MAX_TOKENS"
+        shift 2
+        ;;
+    --reasoning-effort)
+        [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--reasoning-effort requires a value"
+        REASONING_EFFORT=$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')
+        validate_reasoning_effort "$REASONING_EFFORT"
+        save_setting "$REASONING_EFFORT_FILE" "$REASONING_EFFORT"
+        shift 2
+        ;;
+    --extra-body)
+        [ -n "${2:-}" ] || fail "--extra-body requires a JSON object"
+        validate_extra_body "$2"
+        EXTRA_BODY=$(printf '%s' "$2" | jq -c '.')
+        save_setting "$EXTRA_BODY_FILE" "$EXTRA_BODY"
+        shift 2
+        ;;
+    --reset-generation-options)
+        rm -f "$TEMPERATURE_FILE" "$TOP_P_FILE" "$TOP_K_FILE" \
+            "$PRESENCE_PENALTY_FILE" "$MAX_TOKENS_FILE" \
+            "$REASONING_EFFORT_FILE" "$EXTRA_BODY_FILE"
+        TEMPERATURE=""
+        TOP_P=""
+        TOP_K=""
+        PRESENCE_PENALTY=""
+        MAX_TOKENS=""
+        REASONING_EFFORT=""
+        EXTRA_BODY=""
+        shift
         ;;
     --base-url)
         # Check if next argument exists and doesn't start with -
@@ -369,6 +537,13 @@ fi
 if [ -n "$DIFF_SPEC" ] && [ "$MESSAGE_ONLY" = false ] && [ "$BRANCH_NAME_ONLY" = false ]; then
     echo "Error: --diff can only be used with --message-only or --branch-name-only"
     exit 1
+fi
+
+if [ "$PROVIDER" = "$PROVIDER_OLLAMA" ] && [ -n "$REASONING_EFFORT" ]; then
+    case "$REASONING_EFFORT" in
+    none | low | medium | high) ;;
+    *) fail "Ollama supports reasoning effort none, low, medium, or high" ;;
+    esac
 fi
 
 # Set default model based on provider
@@ -517,7 +692,13 @@ trap cleanup EXIT
 TEMP_DIR=$(mktemp -d) || fail "Failed to create temporary directory"
 PROMPT_FILE="$TEMP_DIR/prompt"
 REQUEST_FILE="$TEMP_DIR/request.json"
+EXTRA_BODY_REQUEST_FILE="$TEMP_DIR/extra-body.json"
 printf '%s' "$USER_CONTENT" >"$PROMPT_FILE" || fail "Failed to write prompt to temporary file"
+if [ -n "$EXTRA_BODY" ]; then
+    printf '%s' "$EXTRA_BODY" >"$EXTRA_BODY_REQUEST_FILE" || fail "Failed to write extra request body"
+else
+    printf '%s' '{}' >"$EXTRA_BODY_REQUEST_FILE" || fail "Failed to initialize extra request body"
+fi
 
 # Make the API request
 case "$PROVIDER" in
@@ -529,7 +710,23 @@ case "$PROVIDER" in
     jq -n \
         --arg model "$MODEL" \
         --rawfile prompt "$PROMPT_FILE" \
-        '{model:$model, prompt:$prompt, stream:false}' >"$REQUEST_FILE" ||
+        --arg temperature "$TEMPERATURE" \
+        --arg top_p "$TOP_P" \
+        --arg top_k "$TOP_K" \
+        --arg presence_penalty "$PRESENCE_PENALTY" \
+        --arg max_tokens "$MAX_TOKENS" \
+        --arg reasoning_effort "$REASONING_EFFORT" \
+        --slurpfile extra_body "$EXTRA_BODY_REQUEST_FILE" \
+        '{model:$model, prompt:$prompt, stream:false}
+         | if $temperature == "" then . else .options.temperature = ($temperature | tonumber) end
+         | if $top_p == "" then . else .options.top_p = ($top_p | tonumber) end
+         | if $top_k == "" then . else .options.top_k = ($top_k | tonumber) end
+         | if $presence_penalty == "" then . else .options.presence_penalty = ($presence_penalty | tonumber) end
+         | if $max_tokens == "" then . else .options.num_predict = ($max_tokens | tonumber) end
+         | if $reasoning_effort != "" then
+             .think = (if $reasoning_effort == "none" then false else $reasoning_effort end)
+           else . end
+         | . + $extra_body[0]' >"$REQUEST_FILE" ||
         fail "Failed to generate request JSON"
     ;;
 "$PROVIDER_LMSTUDIO")
@@ -540,6 +737,13 @@ case "$PROVIDER" in
         --arg model "$MODEL" \
         --rawfile content "$PROMPT_FILE" \
         --arg system_prompt "$SYSTEM_PROMPT" \
+        --arg temperature "$TEMPERATURE" \
+        --arg top_p "$TOP_P" \
+        --arg top_k "$TOP_K" \
+        --arg presence_penalty "$PRESENCE_PENALTY" \
+        --arg max_tokens "$MAX_TOKENS" \
+        --arg reasoning_effort "$REASONING_EFFORT" \
+        --slurpfile extra_body "$EXTRA_BODY_REQUEST_FILE" \
         '{
            model: $model,
            stream: false,
@@ -547,7 +751,14 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }' >"$REQUEST_FILE" ||
+         }
+         | if $temperature == "" then . else .temperature = ($temperature | tonumber) end
+         | if $top_p == "" then . else .top_p = ($top_p | tonumber) end
+         | if $top_k == "" then . else .top_k = ($top_k | tonumber) end
+         | if $presence_penalty == "" then . else .presence_penalty = ($presence_penalty | tonumber) end
+         | if $max_tokens == "" then . else .max_tokens = ($max_tokens | tonumber) end
+         | if $reasoning_effort == "" then . else .reasoning_effort = $reasoning_effort end
+         | . + $extra_body[0]' >"$REQUEST_FILE" ||
         fail "Failed to generate request JSON"
     debug_log_file "LMStudio request body:" "$REQUEST_FILE"
     ;;
@@ -564,6 +775,13 @@ case "$PROVIDER" in
         --arg model "$MODEL" \
         --rawfile content "$PROMPT_FILE" \
         --arg system_prompt "$SYSTEM_PROMPT" \
+        --arg temperature "$TEMPERATURE" \
+        --arg top_p "$TOP_P" \
+        --arg top_k "$TOP_K" \
+        --arg presence_penalty "$PRESENCE_PENALTY" \
+        --arg max_tokens "$MAX_TOKENS" \
+        --arg reasoning_effort "$REASONING_EFFORT" \
+        --slurpfile extra_body "$EXTRA_BODY_REQUEST_FILE" \
         '{
            model: $model,
            stream: false,
@@ -571,7 +789,14 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }' >"$REQUEST_FILE" ||
+         }
+         | if $temperature == "" then . else .temperature = ($temperature | tonumber) end
+         | if $top_p == "" then . else .top_p = ($top_p | tonumber) end
+         | if $top_k == "" then . else .top_k = ($top_k | tonumber) end
+         | if $presence_penalty == "" then . else .presence_penalty = ($presence_penalty | tonumber) end
+         | if $max_tokens == "" then . else .max_tokens = ($max_tokens | tonumber) end
+         | if $reasoning_effort == "" then . else .reasoning.effort = $reasoning_effort end
+         | . + $extra_body[0]' >"$REQUEST_FILE" ||
         fail "Failed to generate request JSON"
     ;;
 "$PROVIDER_CUSTOM")
@@ -583,6 +808,13 @@ case "$PROVIDER" in
         --arg model "$MODEL" \
         --rawfile content "$PROMPT_FILE" \
         --arg system_prompt "$SYSTEM_PROMPT" \
+        --arg temperature "$TEMPERATURE" \
+        --arg top_p "$TOP_P" \
+        --arg top_k "$TOP_K" \
+        --arg presence_penalty "$PRESENCE_PENALTY" \
+        --arg max_tokens "$MAX_TOKENS" \
+        --arg reasoning_effort "$REASONING_EFFORT" \
+        --slurpfile extra_body "$EXTRA_BODY_REQUEST_FILE" \
         '{
            stream: false,
            model: $model,
@@ -590,7 +822,14 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }' >"$REQUEST_FILE" ||
+         }
+         | if $temperature == "" then . else .temperature = ($temperature | tonumber) end
+         | if $top_p == "" then . else .top_p = ($top_p | tonumber) end
+         | if $top_k == "" then . else .top_k = ($top_k | tonumber) end
+         | if $presence_penalty == "" then . else .presence_penalty = ($presence_penalty | tonumber) end
+         | if $max_tokens == "" then . else .max_tokens = ($max_tokens | tonumber) end
+         | if $reasoning_effort == "" then . else .reasoning_effort = $reasoning_effort end
+         | . + $extra_body[0]' >"$REQUEST_FILE" ||
         fail "Failed to generate request JSON"
     ;;
 esac

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -25,6 +25,8 @@ BRANCH_NAME_ONLY=false
 UNSTAGED=false
 # Explicit git diff target
 DIFF_SPEC=""
+# Track delayed persistence until provider-specific validation succeeds.
+REASONING_EFFORT_CHANGED=false
 # Default providers and URLs
 PROVIDER_OPENROUTER="openrouter"
 PROVIDER_OLLAMA="ollama"
@@ -134,6 +136,27 @@ validate_reasoning_effort() {
     case "$1" in
     none | minimal | low | medium | high | xhigh | max) ;;
     *) fail "--reasoning-effort must be one of: none, minimal, low, medium, high, xhigh, max" ;;
+    esac
+}
+
+validate_ollama_reasoning_effort() {
+    local model
+    local effort="$2"
+
+    model=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    case "$model" in
+    *gpt-oss*)
+        case "$effort" in
+        low | medium | high) ;;
+        none) fail "Ollama GPT-OSS models cannot disable thinking" ;;
+        *) fail "Ollama GPT-OSS reasoning effort must be low, medium, or high" ;;
+        esac
+        ;;
+    *)
+        if [ "$effort" != "none" ]; then
+            fail "Ollama reasoning effort levels are only supported by GPT-OSS models; use --extra-body with a boolean think field for this model"
+        fi
+        ;;
     esac
 }
 
@@ -397,7 +420,7 @@ while [[ $# -gt 0 ]]; do
         echo "  --max-tokens <n>      Set maximum generated tokens (saves for future use)"
         echo "  --reasoning-effort <level>  Set none/minimal/low/medium/high/xhigh/max"
         echo "  --extra-body <json>   Merge arbitrary JSON object into request body"
-        echo "  --reset-generation-options  Clear saved generation options"
+        echo "  --clear-model-options  Clear saved model options"
         echo "  --use-ollama          Use Ollama as provider (saves for future use)"
         echo "  --use-openrouter      Use OpenRouter as provider (saves for future use)"
         echo "  --use-lmstudio        Use LMStudio as provider (saves for future use)"
@@ -466,7 +489,7 @@ while [[ $# -gt 0 ]]; do
         [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--reasoning-effort requires a value"
         REASONING_EFFORT=$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')
         validate_reasoning_effort "$REASONING_EFFORT"
-        save_setting "$REASONING_EFFORT_FILE" "$REASONING_EFFORT"
+        REASONING_EFFORT_CHANGED=true
         shift 2
         ;;
     --extra-body)
@@ -476,7 +499,7 @@ while [[ $# -gt 0 ]]; do
         save_setting "$EXTRA_BODY_FILE" "$EXTRA_BODY"
         shift 2
         ;;
-    --reset-generation-options)
+    --clear-model-options)
         rm -f "$TEMPERATURE_FILE" "$TOP_P_FILE" "$TOP_K_FILE" \
             "$PRESENCE_PENALTY_FILE" "$MAX_TOKENS_FILE" \
             "$REASONING_EFFORT_FILE" "$EXTRA_BODY_FILE"
@@ -486,6 +509,7 @@ while [[ $# -gt 0 ]]; do
         PRESENCE_PENALTY=""
         MAX_TOKENS=""
         REASONING_EFFORT=""
+        REASONING_EFFORT_CHANGED=false
         EXTRA_BODY=""
         shift
         ;;
@@ -540,10 +564,11 @@ if [ -n "$DIFF_SPEC" ] && [ "$MESSAGE_ONLY" = false ] && [ "$BRANCH_NAME_ONLY" =
 fi
 
 if [ "$PROVIDER" = "$PROVIDER_OLLAMA" ] && [ -n "$REASONING_EFFORT" ]; then
-    case "$REASONING_EFFORT" in
-    none | low | medium | high) ;;
-    *) fail "Ollama supports reasoning effort none, low, medium, or high" ;;
-    esac
+    validate_ollama_reasoning_effort "$MODEL" "$REASONING_EFFORT"
+fi
+
+if [ "$REASONING_EFFORT_CHANGED" = true ]; then
+    save_setting "$REASONING_EFFORT_FILE" "$REASONING_EFFORT"
 fi
 
 # Set default model based on provider

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -9,9 +9,14 @@ TEMPERATURE_FILE="$CONFIG_DIR/temperature"
 TOP_P_FILE="$CONFIG_DIR/top_p"
 TOP_K_FILE="$CONFIG_DIR/top_k"
 PRESENCE_PENALTY_FILE="$CONFIG_DIR/presence_penalty"
-MAX_TOKENS_FILE="$CONFIG_DIR/max_tokens"
+MAX_OUTPUT_TOKENS_FILE="$CONFIG_DIR/max_output_tokens"
+MAX_CONTEXT_TOKENS_FILE="$CONFIG_DIR/max_context_tokens"
 REASONING_EFFORT_FILE="$CONFIG_DIR/reasoning_effort"
 EXTRA_BODY_FILE="$CONFIG_DIR/extra_body"
+DEFAULT_MAX_CONTEXT_TOKENS=131072
+DEFAULT_OUTPUT_TOKEN_RESERVE=4096
+CONTEXT_SAFETY_PERCENT=10
+PROMPT_OVERHEAD_BYTES=4096
 
 # Debug mode flag
 DEBUG=false
@@ -27,6 +32,8 @@ UNSTAGED=false
 DIFF_SPEC=""
 # Track delayed persistence until provider-specific validation succeeds.
 REASONING_EFFORT_CHANGED=false
+MAX_OUTPUT_TOKENS_CHANGED=false
+MAX_CONTEXT_TOKENS_CHANGED=false
 # Default providers and URLs
 PROVIDER_OPENROUTER="openrouter"
 PROVIDER_OLLAMA="ollama"
@@ -168,9 +175,14 @@ validate_extra_body() {
 
 cleanup() {
     if [ -n "${TEMP_DIR:-}" ] && [ "$TEMP_DIR" != "/" ] && [ -d "$TEMP_DIR" ]; then
-        rm -f "$TEMP_DIR/prompt" "$TEMP_DIR/request.json" "$TEMP_DIR/extra-body.json"
+        rm -f "$TEMP_DIR/prompt" "$TEMP_DIR/request.json" "$TEMP_DIR/extra-body.json" \
+            "$TEMP_DIR/diff" "$TEMP_DIR/response.json"
         rmdir "$TEMP_DIR" 2>/dev/null || true
     fi
+}
+
+response_excerpt() {
+    printf '%s' "$1" | tr '\r\n' '  ' | cut -c1-300
 }
 
 # Collect untracked files and represent them as added files in the prompt context.
@@ -265,7 +277,8 @@ print_config() {
     echo "  Top P:            ${TOP_P:-Not set}"
     echo "  Top K:            ${TOP_K:-Not set}"
     echo "  Presence penalty: ${PRESENCE_PENALTY:-Not set}"
-    echo "  Max tokens:       ${MAX_TOKENS:-Not set}"
+    echo "  Max output tokens:  ${MAX_OUTPUT_TOKENS:-Not set}"
+    echo "  Max context tokens: $MAX_CONTEXT_TOKENS"
     echo "  Reasoning effort: ${REASONING_EFFORT:-Not set}"
     if [ -z "$EXTRA_BODY" ]; then
         echo "  Extra body:       Not set"
@@ -303,9 +316,11 @@ TEMPERATURE=$(get_setting "$TEMPERATURE_FILE")
 TOP_P=$(get_setting "$TOP_P_FILE")
 TOP_K=$(get_setting "$TOP_K_FILE")
 PRESENCE_PENALTY=$(get_setting "$PRESENCE_PENALTY_FILE")
-MAX_TOKENS=$(get_setting "$MAX_TOKENS_FILE")
+MAX_OUTPUT_TOKENS=$(get_setting "$MAX_OUTPUT_TOKENS_FILE")
+MAX_CONTEXT_TOKENS=$(get_setting "$MAX_CONTEXT_TOKENS_FILE")
 REASONING_EFFORT=$(get_setting "$REASONING_EFFORT_FILE")
 EXTRA_BODY=$(get_setting "$EXTRA_BODY_FILE")
+[ -n "$MAX_CONTEXT_TOKENS" ] || MAX_CONTEXT_TOKENS="$DEFAULT_MAX_CONTEXT_TOKENS"
 if [ -z "$MODEL" ]; then
     case "$PROVIDER" in
     "$PROVIDER_OLLAMA")
@@ -417,7 +432,8 @@ while [[ $# -gt 0 ]]; do
         echo "  --top-p <n>           Set nucleus sampling probability (0-1; saves for future use)"
         echo "  --top-k <n>           Set top-k sampling count (non-negative integer)"
         echo "  --presence-penalty <n>  Set presence penalty (-2 to 2; saves for future use)"
-        echo "  --max-tokens <n>      Set maximum generated tokens (saves for future use)"
+        echo "  --max-output-tokens <n>  Set maximum generated tokens (saves for future use)"
+        echo "  --max-context-tokens <n> Set model context window (default: 131072)"
         echo "  --reasoning-effort <level>  Set none/minimal/low/medium/high/xhigh/max"
         echo "  --extra-body <json>   Merge arbitrary JSON object into request body"
         echo "  --clear-model-options  Clear saved model options"
@@ -478,11 +494,18 @@ while [[ $# -gt 0 ]]; do
         save_setting "$PRESENCE_PENALTY_FILE" "$PRESENCE_PENALTY"
         shift 2
         ;;
-    --max-tokens)
-        [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--max-tokens requires a value"
-        validate_positive_integer "$2" "--max-tokens"
-        MAX_TOKENS="$2"
-        save_setting "$MAX_TOKENS_FILE" "$MAX_TOKENS"
+    --max-output-tokens)
+        [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--max-output-tokens requires a value"
+        validate_positive_integer "$2" "--max-output-tokens"
+        MAX_OUTPUT_TOKENS="$2"
+        MAX_OUTPUT_TOKENS_CHANGED=true
+        shift 2
+        ;;
+    --max-context-tokens)
+        [ -n "${2:-}" ] && [[ "$2" != -* ]] || fail "--max-context-tokens requires a value"
+        validate_positive_integer "$2" "--max-context-tokens"
+        MAX_CONTEXT_TOKENS="$2"
+        MAX_CONTEXT_TOKENS_CHANGED=true
         shift 2
         ;;
     --reasoning-effort)
@@ -501,13 +524,17 @@ while [[ $# -gt 0 ]]; do
         ;;
     --clear-model-options)
         rm -f "$TEMPERATURE_FILE" "$TOP_P_FILE" "$TOP_K_FILE" \
-            "$PRESENCE_PENALTY_FILE" "$MAX_TOKENS_FILE" \
+            "$PRESENCE_PENALTY_FILE" "$MAX_OUTPUT_TOKENS_FILE" \
+            "$MAX_CONTEXT_TOKENS_FILE" \
             "$REASONING_EFFORT_FILE" "$EXTRA_BODY_FILE"
         TEMPERATURE=""
         TOP_P=""
         TOP_K=""
         PRESENCE_PENALTY=""
-        MAX_TOKENS=""
+        MAX_OUTPUT_TOKENS=""
+        MAX_CONTEXT_TOKENS="$DEFAULT_MAX_CONTEXT_TOKENS"
+        MAX_OUTPUT_TOKENS_CHANGED=false
+        MAX_CONTEXT_TOKENS_CHANGED=false
         REASONING_EFFORT=""
         REASONING_EFFORT_CHANGED=false
         EXTRA_BODY=""
@@ -563,6 +590,26 @@ if [ -n "$DIFF_SPEC" ] && [ "$MESSAGE_ONLY" = false ] && [ "$BRANCH_NAME_ONLY" =
     exit 1
 fi
 
+validate_positive_integer "$MAX_CONTEXT_TOKENS" "--max-context-tokens"
+if [ -n "$MAX_OUTPUT_TOKENS" ]; then
+    validate_positive_integer "$MAX_OUTPUT_TOKENS" "--max-output-tokens"
+    OUTPUT_TOKEN_RESERVE="$MAX_OUTPUT_TOKENS"
+else
+    OUTPUT_TOKEN_RESERVE="$DEFAULT_OUTPUT_TOKEN_RESERVE"
+fi
+
+if [ "$OUTPUT_TOKEN_RESERVE" -ge "$MAX_CONTEXT_TOKENS" ]; then
+    fail "--max-output-tokens must be smaller than --max-context-tokens"
+fi
+
+if [ "$MAX_OUTPUT_TOKENS_CHANGED" = true ]; then
+    save_setting "$MAX_OUTPUT_TOKENS_FILE" "$MAX_OUTPUT_TOKENS"
+fi
+
+if [ "$MAX_CONTEXT_TOKENS_CHANGED" = true ]; then
+    save_setting "$MAX_CONTEXT_TOKENS_FILE" "$MAX_CONTEXT_TOKENS"
+fi
+
 if [ "$PROVIDER" = "$PROVIDER_OLLAMA" ] && [ -n "$REASONING_EFFORT" ]; then
     validate_ollama_reasoning_effort "$MODEL" "$REASONING_EFFORT"
 fi
@@ -603,9 +650,20 @@ elif [ "$UNSTAGED" = false ]; then
     DIFF_ARGS+=(--cached)
 fi
 
+# Keep large prompts and request bodies out of command arguments. Limit diff
+# context so large generated files and logs cannot exceed provider limits.
+TEMP_DIR=""
+trap cleanup EXIT
+TEMP_DIR=$(mktemp -d) || fail "Failed to create temporary directory"
+PROMPT_FILE="$TEMP_DIR/prompt"
+REQUEST_FILE="$TEMP_DIR/request.json"
+EXTRA_BODY_REQUEST_FILE="$TEMP_DIR/extra-body.json"
+DIFF_FILE="$TEMP_DIR/diff"
+RESPONSE_FILE="$TEMP_DIR/response.json"
+
 CHANGES=$(git diff --name-status "${DIFF_ARGS[@]}" | tr '\t' ' ' | sed 's/  */ /g')
 # Get git diff for context
-DIFF_CONTENT=$(git diff "${DIFF_ARGS[@]}")
+git diff "${DIFF_ARGS[@]}" >"$DIFF_FILE" || fail "Failed to read git diff"
 
 if [ "$UNSTAGED" = true ]; then
     UNTRACKED_DATA=$(get_untracked_changes)
@@ -617,7 +675,7 @@ if [ "$UNSTAGED" = true ]; then
     fi
 
     if [ -n "$UNTRACKED_DIFF" ]; then
-        DIFF_CONTENT="${DIFF_CONTENT}${DIFF_CONTENT:+$'\n'}${UNTRACKED_DIFF%$'\n'}"
+        printf '\n%s' "${UNTRACKED_DIFF%$'\n'}" >>"$DIFF_FILE"
     fi
 fi
 
@@ -633,6 +691,26 @@ if [ -z "$CHANGES" ]; then
     fi
     exit 1
 fi
+
+# Use one UTF-8 byte per token as a conservative provider-neutral upper bound.
+# Fixed overhead covers prompt templates, system instructions, and chat framing.
+USABLE_CONTEXT_TOKENS=$((MAX_CONTEXT_TOKENS * (100 - CONTEXT_SAFETY_PERCENT) / 100))
+CHANGES_BYTES=$(printf '%s' "$CHANGES" | wc -c)
+DIFF_BUDGET_BYTES=$((USABLE_CONTEXT_TOKENS - OUTPUT_TOKEN_RESERVE - PROMPT_OVERHEAD_BYTES - CHANGES_BYTES))
+
+if [ "$DIFF_BUDGET_BYTES" -le 0 ]; then
+    fail "Context budget leaves no room for diff content; increase --max-context-tokens or reduce --max-output-tokens"
+fi
+
+DIFF_BYTES=$(wc -c <"$DIFF_FILE")
+if [ "$DIFF_BYTES" -gt "$DIFF_BUDGET_BYTES" ]; then
+    DIFF_CONTENT=$(head -c "$DIFF_BUDGET_BYTES" "$DIFF_FILE")
+    DIFF_CONTENT+=$'\n\n'"[Diff truncated after $DIFF_BUDGET_BYTES bytes.]"
+    debug_log "Diff truncated from $DIFF_BYTES to $DIFF_BUDGET_BYTES bytes"
+else
+    DIFF_CONTENT=$(cat "$DIFF_FILE")
+fi
+debug_log "Token budget: context=$MAX_CONTEXT_TOKENS output=$OUTPUT_TOKEN_RESERVE usable=$USABLE_CONTEXT_TOKENS"
 
 # Set model based on provider if not explicitly specified
 if [ -z "$MODEL" ]; then
@@ -710,14 +788,6 @@ else
     SYSTEM_PROMPT="You are a git commit message generator. Create conventional commit messages."
 fi
 
-# Keep large prompts and request bodies out of command arguments. Passing a
-# large diff through `jq --arg` or `curl -d` can exceed the OS argument limit.
-TEMP_DIR=""
-trap cleanup EXIT
-TEMP_DIR=$(mktemp -d) || fail "Failed to create temporary directory"
-PROMPT_FILE="$TEMP_DIR/prompt"
-REQUEST_FILE="$TEMP_DIR/request.json"
-EXTRA_BODY_REQUEST_FILE="$TEMP_DIR/extra-body.json"
 printf '%s' "$USER_CONTENT" >"$PROMPT_FILE" || fail "Failed to write prompt to temporary file"
 if [ -n "$EXTRA_BODY" ]; then
     printf '%s' "$EXTRA_BODY" >"$EXTRA_BODY_REQUEST_FILE" || fail "Failed to write extra request body"
@@ -739,7 +809,7 @@ case "$PROVIDER" in
         --arg top_p "$TOP_P" \
         --arg top_k "$TOP_K" \
         --arg presence_penalty "$PRESENCE_PENALTY" \
-        --arg max_tokens "$MAX_TOKENS" \
+        --arg max_output_tokens "$MAX_OUTPUT_TOKENS" \
         --arg reasoning_effort "$REASONING_EFFORT" \
         --slurpfile extra_body "$EXTRA_BODY_REQUEST_FILE" \
         '{model:$model, prompt:$prompt, stream:false}
@@ -747,7 +817,7 @@ case "$PROVIDER" in
          | if $top_p == "" then . else .options.top_p = ($top_p | tonumber) end
          | if $top_k == "" then . else .options.top_k = ($top_k | tonumber) end
          | if $presence_penalty == "" then . else .options.presence_penalty = ($presence_penalty | tonumber) end
-         | if $max_tokens == "" then . else .options.num_predict = ($max_tokens | tonumber) end
+         | if $max_output_tokens == "" then . else .options.num_predict = ($max_output_tokens | tonumber) end
          | if $reasoning_effort != "" then
              .think = (if $reasoning_effort == "none" then false else $reasoning_effort end)
            else . end
@@ -766,7 +836,7 @@ case "$PROVIDER" in
         --arg top_p "$TOP_P" \
         --arg top_k "$TOP_K" \
         --arg presence_penalty "$PRESENCE_PENALTY" \
-        --arg max_tokens "$MAX_TOKENS" \
+        --arg max_output_tokens "$MAX_OUTPUT_TOKENS" \
         --arg reasoning_effort "$REASONING_EFFORT" \
         --slurpfile extra_body "$EXTRA_BODY_REQUEST_FILE" \
         '{
@@ -781,7 +851,7 @@ case "$PROVIDER" in
          | if $top_p == "" then . else .top_p = ($top_p | tonumber) end
          | if $top_k == "" then . else .top_k = ($top_k | tonumber) end
          | if $presence_penalty == "" then . else .presence_penalty = ($presence_penalty | tonumber) end
-         | if $max_tokens == "" then . else .max_tokens = ($max_tokens | tonumber) end
+         | if $max_output_tokens == "" then . else .max_tokens = ($max_output_tokens | tonumber) end
          | if $reasoning_effort == "" then . else .reasoning_effort = $reasoning_effort end
          | . + $extra_body[0]' >"$REQUEST_FILE" ||
         fail "Failed to generate request JSON"
@@ -804,7 +874,7 @@ case "$PROVIDER" in
         --arg top_p "$TOP_P" \
         --arg top_k "$TOP_K" \
         --arg presence_penalty "$PRESENCE_PENALTY" \
-        --arg max_tokens "$MAX_TOKENS" \
+        --arg max_output_tokens "$MAX_OUTPUT_TOKENS" \
         --arg reasoning_effort "$REASONING_EFFORT" \
         --slurpfile extra_body "$EXTRA_BODY_REQUEST_FILE" \
         '{
@@ -819,7 +889,7 @@ case "$PROVIDER" in
          | if $top_p == "" then . else .top_p = ($top_p | tonumber) end
          | if $top_k == "" then . else .top_k = ($top_k | tonumber) end
          | if $presence_penalty == "" then . else .presence_penalty = ($presence_penalty | tonumber) end
-         | if $max_tokens == "" then . else .max_tokens = ($max_tokens | tonumber) end
+         | if $max_output_tokens == "" then . else .max_tokens = ($max_output_tokens | tonumber) end
          | if $reasoning_effort == "" then . else .reasoning.effort = $reasoning_effort end
          | . + $extra_body[0]' >"$REQUEST_FILE" ||
         fail "Failed to generate request JSON"
@@ -837,7 +907,7 @@ case "$PROVIDER" in
         --arg top_p "$TOP_P" \
         --arg top_k "$TOP_K" \
         --arg presence_penalty "$PRESENCE_PENALTY" \
-        --arg max_tokens "$MAX_TOKENS" \
+        --arg max_output_tokens "$MAX_OUTPUT_TOKENS" \
         --arg reasoning_effort "$REASONING_EFFORT" \
         --slurpfile extra_body "$EXTRA_BODY_REQUEST_FILE" \
         '{
@@ -852,7 +922,7 @@ case "$PROVIDER" in
          | if $top_p == "" then . else .top_p = ($top_p | tonumber) end
          | if $top_k == "" then . else .top_k = ($top_k | tonumber) end
          | if $presence_penalty == "" then . else .presence_penalty = ($presence_penalty | tonumber) end
-         | if $max_tokens == "" then . else .max_tokens = ($max_tokens | tonumber) end
+         | if $max_output_tokens == "" then . else .max_tokens = ($max_output_tokens | tonumber) end
          | if $reasoning_effort == "" then . else .reasoning_effort = $reasoning_effort end
          | . + $extra_body[0]' >"$REQUEST_FILE" ||
         fail "Failed to generate request JSON"
@@ -872,65 +942,50 @@ for header in "${HEADERS[@]}"; do
     CURL_HEADERS+=(-H "$header")
 done
 
-RESPONSE=$(curl -s -X POST "$BASE_URL/$ENDPOINT" \
+HTTP_STATUS=$(curl -sS -o "$RESPONSE_FILE" -w '%{http_code}' \
+    -X POST "$BASE_URL/$ENDPOINT" \
     "${CURL_HEADERS[@]}" \
-    --data-binary "@$REQUEST_FILE")
+    --data-binary "@$REQUEST_FILE") || fail "API request failed"
+RESPONSE=$(cat "$RESPONSE_FILE")
 debug_log "API response received" "$RESPONSE"
+
+if ! [[ "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]]; then
+    if printf '%s' "$RESPONSE" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        ERROR=$(printf '%s' "$RESPONSE" |
+            jq -r '.error.message // .error // .message // empty | if type == "string" then . else tostring end')
+    else
+        ERROR=$(response_excerpt "$RESPONSE")
+    fi
+    [ -n "$ERROR" ] || ERROR="empty response"
+    fail "API request failed (HTTP $HTTP_STATUS): $ERROR"
+fi
+
+if ! printf '%s' "$RESPONSE" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    ERROR=$(response_excerpt "$RESPONSE")
+    [ -n "$ERROR" ] || ERROR="empty response"
+    fail "Provider returned invalid JSON (HTTP $HTTP_STATUS): $ERROR"
+fi
+
+if printf '%s' "$RESPONSE" | jq -e '.error != null' >/dev/null 2>&1; then
+    ERROR=$(printf '%s' "$RESPONSE" |
+        jq -r '.error.message // .error | if type == "string" then . else tostring end')
+    fail "Provider error: $ERROR"
+fi
 
 # Extract and clean the commit message
 case "$PROVIDER" in
 "$PROVIDER_OLLAMA")
     # For Ollama, extract content from non-streaming response
-    if echo "$RESPONSE" | grep -q "404 page not found"; then
-        echo "Error: Ollama API endpoint not found. Make sure Ollama is running and try again."
-        echo "Run: ollama serve"
-        exit 1
-    fi
-    if echo "$RESPONSE" | grep -q "error"; then
-        ERROR=$(echo "$RESPONSE" | jq -r '.error')
-        echo "Error from Ollama: $ERROR"
-        exit 1
-    fi
-    RESULT_MESSAGE=$(echo "$RESPONSE" | jq -r '.response // empty')
-    if [ -z "$RESULT_MESSAGE" ]; then
-        echo "Error: Failed to get response from Ollama. Response: $RESPONSE"
-        exit 1
-    fi
+    RESULT_MESSAGE=$(printf '%s' "$RESPONSE" | jq -r '.response // empty')
     ;;
 "$PROVIDER_LMSTUDIO")
     # For LMStudio, extract content from response
     debug_log "LMStudio raw response:" "$RESPONSE"
-
-    # Check if response is HTML error page
-    if echo "$RESPONSE" | grep -q "<!DOCTYPE html>"; then
-        echo "Error: LMStudio API returned HTML error. Make sure LMStudio is running and the API is accessible."
-        echo "Response: $RESPONSE"
-        exit 1
-    fi
-
-    # Check for JSON error - only if there's an actual error field with content
-    if echo "$RESPONSE" | jq -e '.error' >/dev/null 2>&1; then
-        ERROR=$(echo "$RESPONSE" | jq -r '.error.message // .error' 2>/dev/null)
-        echo "Error from LMStudio: $ERROR"
-        exit 1
-    fi
-
-    # Try to extract content with proper error handling
-    RESULT_MESSAGE=$(echo "$RESPONSE" | jq -r '.choices[0].message.content' 2>/dev/null)
-    if [ $? -ne 0 ] || [ -z "$RESULT_MESSAGE" ] || [ "$RESULT_MESSAGE" = "null" ]; then
-        echo "Error: Failed to parse LMStudio response. Response format may be unexpected."
-        echo "Response: $RESPONSE"
-        exit 1
-    fi
+    RESULT_MESSAGE=$(printf '%s' "$RESPONSE" | jq -r '.choices[0].message.content // empty')
     ;;
 "$PROVIDER_OPENROUTER" | "$PROVIDER_CUSTOM")
     # For OpenRouter and custom providers
-    RESULT_MESSAGE=$(echo "$RESPONSE" | jq -r '.choices[0].message.content')
-
-    # If jq fails or returns null, fallback to grep method
-    if [ -z "$RESULT_MESSAGE" ] || [ "$RESULT_MESSAGE" = "null" ]; then
-        RESULT_MESSAGE=$(echo "$RESPONSE" | grep -o '"content":"[^"]*"' | cut -d'"' -f4)
-    fi
+    RESULT_MESSAGE=$(printf '%s' "$RESPONSE" | jq -r '.choices[0].message.content // empty')
     ;;
 esac
 
@@ -946,9 +1001,7 @@ RESULT_MESSAGE=$(echo "$RESULT_MESSAGE" |
 debug_log "Extracted commit message" "$RESULT_MESSAGE"
 
 if [ -z "$RESULT_MESSAGE" ]; then
-    echo "Failed to generate commit message. API response:"
-    echo "$RESPONSE"
-    exit 1
+    fail "Provider response did not include generated content"
 fi
 
 if [ "$MESSAGE_ONLY" = true ] || [ "$BRANCH_NAME_ONLY" = true ]; then
@@ -964,21 +1017,15 @@ fi
 
 # Execute git commit
 debug_log "Executing git commit"
-git commit -m "$RESULT_MESSAGE"
-
-if [ $? -ne 0 ]; then
-    echo "Failed to commit changes"
-    exit 1
+if ! git commit -m "$RESULT_MESSAGE"; then
+    fail "Failed to commit changes"
 fi
 
 # Push to origin if flag is set
 if [ "$PUSH" = true ]; then
     debug_log "Pushing to origin"
-    git push origin
-
-    if [ $? -ne 0 ]; then
-        echo "Failed to push changes"
-        exit 1
+    if ! git push origin; then
+        fail "Failed to push changes"
     fi
     echo "Successfully pushed changes to origin"
 fi

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -45,6 +45,21 @@ debug_log() {
     fi
 }
 
+debug_log_file() {
+    if [ "$DEBUG" = true ]; then
+        echo "DEBUG: $1"
+        echo "DEBUG: Content >>>"
+        cat "$2"
+        echo "DEBUG: <<<"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TEMP_DIR:-}" ] && [ -d "$TEMP_DIR" ]; then
+        rm -rf "$TEMP_DIR"
+    fi
+}
+
 # Collect untracked files and represent them as added files in the prompt context.
 get_untracked_changes() {
     local files=""
@@ -485,6 +500,17 @@ else
     SYSTEM_PROMPT="You are a git commit message generator. Create conventional commit messages."
 fi
 
+# Keep large prompts and request bodies out of command arguments. Passing a
+# large diff through `jq --arg` or `curl -d` can exceed the OS argument limit.
+TEMP_DIR=$(mktemp -d) || {
+    echo "Error: Failed to create temporary directory"
+    exit 1
+}
+trap cleanup EXIT
+PROMPT_FILE="$TEMP_DIR/prompt"
+REQUEST_FILE="$TEMP_DIR/request.json"
+printf '%s' "$USER_CONTENT" >"$PROMPT_FILE"
+
 # Make the API request
 case "$PROVIDER" in
 "$PROVIDER_OLLAMA")
@@ -492,18 +518,18 @@ case "$PROVIDER" in
     ENDPOINT="api/generate"
     HEADERS=(-H "Content-Type: application/json")
     BASE_URL="http://localhost:11434"
-    REQUEST_BODY=$(jq -n \
+    jq -n \
         --arg model "$MODEL" \
-        --arg prompt "$USER_CONTENT" \
-        '{model:$model, prompt:$prompt, stream:false}')
+        --rawfile prompt "$PROMPT_FILE" \
+        '{model:$model, prompt:$prompt, stream:false}' >"$REQUEST_FILE"
     ;;
 "$PROVIDER_LMSTUDIO")
     debug_log "Making API request to LMStudio"
     ENDPOINT="chat/completions"
     HEADERS=(-H "Content-Type: application/json")
-    REQUEST_BODY=$(jq -n \
+    jq -n \
         --arg model "$MODEL" \
-        --arg content "$USER_CONTENT" \
+        --rawfile content "$PROMPT_FILE" \
         --arg system_prompt "$SYSTEM_PROMPT" \
         '{
            model: $model,
@@ -512,8 +538,8 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }')
-    debug_log "LMStudio request body:" "$REQUEST_BODY"
+         }' >"$REQUEST_FILE"
+    debug_log_file "LMStudio request body:" "$REQUEST_FILE"
     ;;
 "$PROVIDER_OPENROUTER")
     debug_log "Making API request to OpenRouter"
@@ -524,9 +550,9 @@ case "$PROVIDER" in
         "Content-Type: application/json"
         "X-Title: cmai - AI Commit Message Generator"
     )
-    REQUEST_BODY=$(jq -n \
+    jq -n \
         --arg model "$MODEL" \
-        --arg content "$USER_CONTENT" \
+        --rawfile content "$PROMPT_FILE" \
         --arg system_prompt "$SYSTEM_PROMPT" \
         '{
            model: $model,
@@ -535,16 +561,16 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }')
+         }' >"$REQUEST_FILE"
     ;;
 "$PROVIDER_CUSTOM")
     debug_log "Making API request to custom provider"
     ENDPOINT="chat/completions"
     HEADERS=(-H "Content-Type: application/json")
     [ -n "$API_KEY" ] && HEADERS+=(-H "Authorization: Bearer ${API_KEY}")
-    REQUEST_BODY=$(jq -n \
+    jq -n \
         --arg model "$MODEL" \
-        --arg content "$USER_CONTENT" \
+        --rawfile content "$PROMPT_FILE" \
         --arg system_prompt "$SYSTEM_PROMPT" \
         '{
            stream: false,
@@ -553,7 +579,7 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }')
+         }' >"$REQUEST_FILE"
     ;;
 esac
 
@@ -562,7 +588,7 @@ debug_log "Using provider: $PROVIDER"
 debug_log "Provider endpoint: $ENDPOINT"
 debug_log "Request headers: ${HEADERS[*]}"
 debug_log "Request model: ${MODEL}"
-debug_log "Request body: $REQUEST_BODY"
+debug_log_file "Request body:" "$REQUEST_FILE"
 
 # Convert headers array to proper curl format
 CURL_HEADERS=()
@@ -572,7 +598,7 @@ done
 
 RESPONSE=$(curl -s -X POST "$BASE_URL/$ENDPOINT" \
     "${CURL_HEADERS[@]}" \
-    -d "$REQUEST_BODY")
+    --data-binary "@$REQUEST_FILE")
 debug_log "API response received" "$RESPONSE"
 
 # Extract and clean the commit message

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -185,6 +185,23 @@ response_excerpt() {
     printf '%s' "$1" | tr '\r\n' '  ' | cut -c1-300
 }
 
+truncate_file_at_line_boundary() {
+    local file="$1"
+    local max_bytes="$2"
+
+    LC_ALL=C awk -v max_bytes="$max_bytes" '
+        {
+            line = $0 ORS
+            line_bytes = length(line)
+            if (bytes + line_bytes > max_bytes) {
+                exit
+            }
+            printf "%s", line
+            bytes += line_bytes
+        }
+    ' "$file"
+}
+
 # Collect untracked files and represent them as added files in the prompt context.
 get_untracked_changes() {
     local files=""
@@ -704,9 +721,9 @@ fi
 
 DIFF_BYTES=$(wc -c <"$DIFF_FILE")
 if [ "$DIFF_BYTES" -gt "$DIFF_BUDGET_BYTES" ]; then
-    DIFF_CONTENT=$(head -c "$DIFF_BUDGET_BYTES" "$DIFF_FILE")
-    DIFF_CONTENT+=$'\n\n'"[Diff truncated after $DIFF_BUDGET_BYTES bytes.]"
-    debug_log "Diff truncated from $DIFF_BYTES to $DIFF_BUDGET_BYTES bytes"
+    DIFF_CONTENT=$(truncate_file_at_line_boundary "$DIFF_FILE" "$DIFF_BUDGET_BYTES")
+    DIFF_CONTENT+=$'\n\n'"[Diff truncated to $DIFF_BUDGET_BYTES-byte budget.]"
+    debug_log "Diff truncated from $DIFF_BYTES bytes to $DIFF_BUDGET_BYTES-byte budget"
 else
     DIFF_CONTENT=$(cat "$DIFF_FILE")
 fi
@@ -966,7 +983,7 @@ if ! printf '%s' "$RESPONSE" | jq -e 'type == "object"' >/dev/null 2>&1; then
     fail "Provider returned invalid JSON (HTTP $HTTP_STATUS): $ERROR"
 fi
 
-if printf '%s' "$RESPONSE" | jq -e '.error != null' >/dev/null 2>&1; then
+if printf '%s' "$RESPONSE" | jq -e '.error' >/dev/null 2>&1; then
     ERROR=$(printf '%s' "$RESPONSE" |
         jq -r '.error.message // .error | if type == "string" then . else tostring end')
     fail "Provider error: $ERROR"

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -49,9 +49,18 @@ debug_log_file() {
     if [ "$DEBUG" = true ]; then
         echo "DEBUG: $1"
         echo "DEBUG: Content >>>"
-        cat "$2"
+        if [ -f "${2:-}" ] && [ -r "${2:-}" ]; then
+            cat "$2"
+        else
+            echo "(empty, missing, or unreadable file)"
+        fi
         echo "DEBUG: <<<"
     fi
+}
+
+fail() {
+    echo "Error: $1" 1>&2
+    exit 1
 }
 
 cleanup() {
@@ -502,14 +511,12 @@ fi
 
 # Keep large prompts and request bodies out of command arguments. Passing a
 # large diff through `jq --arg` or `curl -d` can exceed the OS argument limit.
-TEMP_DIR=$(mktemp -d) || {
-    echo "Error: Failed to create temporary directory"
-    exit 1
-}
+TEMP_DIR=""
 trap cleanup EXIT
+TEMP_DIR=$(mktemp -d) || fail "Failed to create temporary directory"
 PROMPT_FILE="$TEMP_DIR/prompt"
 REQUEST_FILE="$TEMP_DIR/request.json"
-printf '%s' "$USER_CONTENT" >"$PROMPT_FILE"
+printf '%s' "$USER_CONTENT" >"$PROMPT_FILE" || fail "Failed to write prompt to temporary file"
 
 # Make the API request
 case "$PROVIDER" in
@@ -521,7 +528,8 @@ case "$PROVIDER" in
     jq -n \
         --arg model "$MODEL" \
         --rawfile prompt "$PROMPT_FILE" \
-        '{model:$model, prompt:$prompt, stream:false}' >"$REQUEST_FILE"
+        '{model:$model, prompt:$prompt, stream:false}' >"$REQUEST_FILE" ||
+        fail "Failed to generate request JSON"
     ;;
 "$PROVIDER_LMSTUDIO")
     debug_log "Making API request to LMStudio"
@@ -538,7 +546,8 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }' >"$REQUEST_FILE"
+         }' >"$REQUEST_FILE" ||
+        fail "Failed to generate request JSON"
     debug_log_file "LMStudio request body:" "$REQUEST_FILE"
     ;;
 "$PROVIDER_OPENROUTER")
@@ -561,7 +570,8 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }' >"$REQUEST_FILE"
+         }' >"$REQUEST_FILE" ||
+        fail "Failed to generate request JSON"
     ;;
 "$PROVIDER_CUSTOM")
     debug_log "Making API request to custom provider"
@@ -579,7 +589,8 @@ case "$PROVIDER" in
              {role:"system", content:$system_prompt},
              {role:"user",   content:$content}
            ]
-         }' >"$REQUEST_FILE"
+         }' >"$REQUEST_FILE" ||
+        fail "Failed to generate request JSON"
     ;;
 esac
 

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -64,8 +64,9 @@ fail() {
 }
 
 cleanup() {
-    if [ -n "${TEMP_DIR:-}" ] && [ -d "$TEMP_DIR" ]; then
-        rm -rf "$TEMP_DIR"
+    if [ -n "${TEMP_DIR:-}" ] && [ "$TEMP_DIR" != "/" ] && [ -d "$TEMP_DIR" ]; then
+        rm -f "$TEMP_DIR/prompt" "$TEMP_DIR/request.json"
+        rmdir "$TEMP_DIR" 2>/dev/null || true
     fi
 }
 

--- a/tests/git-commit-test.sh
+++ b/tests/git-commit-test.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$ROOT_DIR/git-commit.sh"
+TEST_DIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$TEST_DIR"
+}
+
+fail_test() {
+    echo "FAIL: $1" 1>&2
+    exit 1
+}
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+
+    grep -Fq -- "$expected" "$file" || fail_test "$file does not contain: $expected"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$TEST_DIR/bin" "$TEST_DIR/home/.config/git-commit-ai" "$TEST_DIR/repo" "$TEST_DIR/state"
+printf '%s\n' custom >"$TEST_DIR/home/.config/git-commit-ai/provider"
+printf '%s\n' https://provider.test/v1 >"$TEST_DIR/home/.config/git-commit-ai/base_url"
+printf '%s\n' test-model >"$TEST_DIR/home/.config/git-commit-ai/model"
+
+export HOME="$TEST_DIR/home"
+export PATH="$TEST_DIR/bin:$PATH"
+export TEST_STATE="$TEST_DIR/state"
+
+cat >"$TEST_DIR/bin/curl" <<'EOF'
+#!/bin/bash
+
+output_file=""
+request_file=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    -o)
+        output_file="$2"
+        shift 2
+        ;;
+    -w)
+        shift 2
+        ;;
+    --data-binary)
+        request_file=${2#@}
+        shift 2
+        ;;
+    *)
+        shift
+        ;;
+    esac
+done
+
+jq -r '.messages[1].content' "$request_file" >"$TEST_STATE/prompt"
+cp "$request_file" "$TEST_STATE/request.json"
+printf '%s' "$FAKE_RESPONSE_BODY" >"$output_file"
+printf '%s' "$FAKE_HTTP_STATUS"
+EOF
+chmod +x "$TEST_DIR/bin/curl"
+
+(
+    cd "$TEST_DIR/repo" || exit 1
+    git init -q
+    : >isenstedt-pg-ph-f3tv6x-a-p3rucw-20260716-103832.log
+    awk 'BEGIN { for (i = 0; i < 25000; i++) print "Thu, 16 Oct 2025 [CRITICAL] database connection failed with a long stack trace" }' \
+        >isenstedt-pg-ph-f3tv6x-a-p3rucw-20260716-122750.log
+    git add .
+) || fail_test "failed to create fixture repository"
+
+export FAKE_HTTP_STATUS=200
+export FAKE_RESPONSE_BODY='{"choices":[{"message":{"content":"chore(logs): add diagnostic logs"}}]}'
+if ! (
+    cd "$TEST_DIR/repo" || exit 1
+    "$SCRIPT" --message-only
+) >"$TEST_DIR/output" 2>"$TEST_DIR/error"; then
+    fail_test "large diff request failed"
+fi
+
+[ "$(cat "$TEST_DIR/output")" = "chore(logs): add diagnostic logs" ] ||
+    fail_test "generated message was not returned"
+[ "$(wc -c <"$TEST_DIR/state/prompt")" -lt 112000 ] ||
+    fail_test "prompt exceeded bounded diff size"
+assert_contains "$TEST_DIR/state/prompt" "isenstedt-pg-ph-f3tv6x-a-p3rucw-20260716-103832.log"
+assert_contains "$TEST_DIR/state/prompt" "isenstedt-pg-ph-f3tv6x-a-p3rucw-20260716-122750.log"
+assert_contains "$TEST_DIR/state/prompt" "[Diff truncated after "
+if ! jq -e 'has("max_tokens") | not' "$TEST_DIR/state/request.json" >/dev/null; then
+    fail_test "default output reserve was sent as an API limit"
+fi
+
+if ! (
+    cd "$TEST_DIR/repo" || exit 1
+    "$SCRIPT" --message-only --max-output-tokens 512 --max-context-tokens 32768
+) >"$TEST_DIR/output" 2>"$TEST_DIR/error"; then
+    fail_test "explicit token budgets failed"
+fi
+[ "$(jq -r '.max_tokens' "$TEST_DIR/state/request.json")" = 512 ] ||
+    fail_test "max output tokens were not sent to provider"
+[ "$(wc -c <"$TEST_DIR/state/prompt")" -lt 26000 ] ||
+    fail_test "custom context window did not reduce prompt size"
+[ "$(cat "$TEST_DIR/home/.config/git-commit-ai/max_output_tokens")" = 512 ] ||
+    fail_test "max output tokens were not saved"
+[ "$(cat "$TEST_DIR/home/.config/git-commit-ai/max_context_tokens")" = 32768 ] ||
+    fail_test "max context tokens were not saved"
+
+"$SCRIPT" --print-config >"$TEST_DIR/output" 2>"$TEST_DIR/error" ||
+    fail_test "print config failed"
+assert_contains "$TEST_DIR/output" "Max output tokens:  512"
+assert_contains "$TEST_DIR/output" "Max context tokens: 32768"
+
+"$SCRIPT" --help >"$TEST_DIR/output" 2>"$TEST_DIR/error" ||
+    fail_test "help failed"
+assert_contains "$TEST_DIR/output" "--max-output-tokens <n>"
+assert_contains "$TEST_DIR/output" "--max-context-tokens <n>"
+
+if (
+    cd "$TEST_DIR/repo" || exit 1
+    "$SCRIPT" --message-only --max-output-tokens 40000
+) >"$TEST_DIR/output" 2>"$TEST_DIR/error"; then
+    fail_test "output budget larger than context unexpectedly succeeded"
+fi
+assert_contains "$TEST_DIR/error" "--max-output-tokens must be smaller than --max-context-tokens"
+[ "$(cat "$TEST_DIR/home/.config/git-commit-ai/max_output_tokens")" = 512 ] ||
+    fail_test "invalid output budget overwrote saved value"
+
+if (
+    cd "$TEST_DIR/repo" || exit 1
+    "$SCRIPT" --message-only --max-tokens 512
+) >"$TEST_DIR/output" 2>"$TEST_DIR/error"; then
+    fail_test "removed --max-tokens option unexpectedly succeeded"
+fi
+assert_contains "$TEST_DIR/output" "Unknown argument --max-tokens"
+
+export FAKE_HTTP_STATUS=413
+export FAKE_RESPONSE_BODY='Request Entity Too Large'
+if (
+    cd "$TEST_DIR/repo" || exit 1
+    "$SCRIPT" --message-only
+) >"$TEST_DIR/output" 2>"$TEST_DIR/error"; then
+    fail_test "HTTP error unexpectedly succeeded"
+fi
+assert_contains "$TEST_DIR/error" "API request failed (HTTP 413): Request Entity Too Large"
+if grep -Fq "jq: parse error" "$TEST_DIR/error"; then
+    fail_test "raw jq parse error leaked to user"
+fi
+
+export FAKE_HTTP_STATUS=200
+export FAKE_RESPONSE_BODY='upstream request failed'
+if (
+    cd "$TEST_DIR/repo" || exit 1
+    "$SCRIPT" --message-only
+) >"$TEST_DIR/output" 2>"$TEST_DIR/error"; then
+    fail_test "invalid JSON response unexpectedly succeeded"
+fi
+assert_contains "$TEST_DIR/error" "Provider returned invalid JSON (HTTP 200): upstream request failed"
+if grep -Fq "jq: parse error" "$TEST_DIR/error"; then
+    fail_test "raw jq parse error leaked to user"
+fi
+
+echo "PASS: git-commit tests"

--- a/tests/git-commit-test.sh
+++ b/tests/git-commit-test.sh
@@ -26,10 +26,15 @@ mkdir -p "$TEST_DIR/bin" "$TEST_DIR/home/.config/git-commit-ai" "$TEST_DIR/repo"
 printf '%s\n' custom >"$TEST_DIR/home/.config/git-commit-ai/provider"
 printf '%s\n' https://provider.test/v1 >"$TEST_DIR/home/.config/git-commit-ai/base_url"
 printf '%s\n' test-model >"$TEST_DIR/home/.config/git-commit-ai/model"
+printf '%s\n' 999999 >"$TEST_DIR/home/.config/git-commit-ai/max_tokens"
 
 export HOME="$TEST_DIR/home"
 export PATH="$TEST_DIR/bin:$PATH"
 export TEST_STATE="$TEST_DIR/state"
+
+"$SCRIPT" --print-config >"$TEST_DIR/output" 2>"$TEST_DIR/error" ||
+    fail_test "print config with legacy setting failed"
+assert_contains "$TEST_DIR/output" "Max output tokens:  Not set"
 
 cat >"$TEST_DIR/bin/curl" <<'EOF'
 #!/bin/bash
@@ -67,16 +72,33 @@ chmod +x "$TEST_DIR/bin/curl"
     cd "$TEST_DIR/repo" || exit 1
     git init -q
     : >isenstedt-pg-ph-f3tv6x-a-p3rucw-20260716-103832.log
-    awk 'BEGIN { for (i = 0; i < 25000; i++) print "Thu, 16 Oct 2025 [CRITICAL] database connection failed with a long stack trace" }' \
+    awk 'BEGIN { for (i = 0; i < 25000; i++) { printf "[CRITICAL] xx"; for (j = 0; j < 40; j++) printf "€"; print "" } }' \
         >isenstedt-pg-ph-f3tv6x-a-p3rucw-20260716-122750.log
     git add .
 ) || fail_test "failed to create fixture repository"
 
-export FAKE_HTTP_STATUS=200
-export FAKE_RESPONSE_BODY='{"choices":[{"message":{"content":"chore(logs): add diagnostic logs"}}]}'
+# Ensure this fixture would expose byte-wise truncation splitting a UTF-8 code point.
 if ! (
     cd "$TEST_DIR/repo" || exit 1
-    "$SCRIPT" --message-only
+    changes=$(git diff --name-status --cached | tr '\t' ' ' | sed 's/  */ /g')
+    changes_bytes=$(printf '%s' "$changes" | wc -c)
+    diff_budget=$((131071 * 90 / 100 - 4096 - 4096 - changes_bytes))
+    git diff --cached >"$TEST_DIR/state/full-diff"
+    head -c "$diff_budget" "$TEST_DIR/state/full-diff" >"$TEST_DIR/state/byte-truncated-diff"
+    last_byte=$(tail -c 1 "$TEST_DIR/state/byte-truncated-diff" | od -An -tx1 | tr -d ' \n')
+    if [ "$last_byte" != e2 ] && [ "$last_byte" != 82 ]; then
+        echo "fixture ended with byte $last_byte" 1>&2
+        exit 1
+    fi
+); then
+    fail_test "UTF-8 fixture does not split a code point under byte-wise truncation"
+fi
+
+export FAKE_HTTP_STATUS=200
+export FAKE_RESPONSE_BODY='{"error":false,"choices":[{"message":{"content":"chore(logs): add diagnostic logs"}}]}'
+if ! (
+    cd "$TEST_DIR/repo" || exit 1
+    "$SCRIPT" --message-only --max-context-tokens 131071
 ) >"$TEST_DIR/output" 2>"$TEST_DIR/error"; then
     fail_test "large diff request failed"
 fi
@@ -87,7 +109,10 @@ fi
     fail_test "prompt exceeded bounded diff size"
 assert_contains "$TEST_DIR/state/prompt" "isenstedt-pg-ph-f3tv6x-a-p3rucw-20260716-103832.log"
 assert_contains "$TEST_DIR/state/prompt" "isenstedt-pg-ph-f3tv6x-a-p3rucw-20260716-122750.log"
-assert_contains "$TEST_DIR/state/prompt" "[Diff truncated after "
+assert_contains "$TEST_DIR/state/prompt" "[Diff truncated to "
+if grep -Fq '�' "$TEST_DIR/state/prompt"; then
+    fail_test "diff truncation introduced invalid UTF-8 replacement character"
+fi
 if ! jq -e 'has("max_tokens") | not' "$TEST_DIR/state/request.json" >/dev/null; then
     fail_test "default output reserve was sent as an API limit"
 fi


### PR DESCRIPTION
* feat(cli): include untracked files when using --unstaged
  * Updated README to clarify that `--unstaged` now processes both unstaged and untracked changes.
  * Added `get_untracked_changes` function to collect untracked files and their diffs.
  * Adjusted help text to describe the expanded behavior of `--unstaged`.
  * Modified change detection logic to merge untracked file info into the overall diff and file list when `--unstaged` is enabled.
  * Updated no‑change messages to reference unstaged or untracked files.
* fix(diff): make diff spec more robust
* feat(cli): add --diff option for custom diff range
  * Document new `--diff` flag in `README` with usage examples for message and branch name generation.
  * Add `DIFF_SPEC` variable and parsing for `--diff` in the script.
  * Implement validation to prevent conflicting use of `--diff` with `--unstaged` and enforce usage only with `--message-only` or `--branch-name-only`.
  * Update help output to include the new option.
  * Adjust diff handling to use the provided diff target or default to staged changes.

