### PR TITLE
Prevent quadratic matching on untracked diffs

### DIFF
--- a/git-commit.sh
+++ b/git-commit.sh
@@ -203,18 +203,16 @@ truncate_file_at_line_boundary() {
 }
 
 # Collect untracked files and represent them as added files in the prompt context.
+# Prints the file list on stdout and appends the diffs to the given file, keeping
+# large diffs out of shell strings (pattern matching on them is quadratic).
 get_untracked_changes() {
-    local files=""
-    local diffs=""
+    local diff_file="$1"
     local file=""
 
     while IFS= read -r -d '' file; do
-        files+="A $file"$'\n'
-        diffs+=$(git diff --no-index -- /dev/null "$file" 2>/dev/null || true)
-        diffs+=$'\n'
+        printf 'A %s\n' "$file"
+        git diff --no-index -- /dev/null "$file" >>"$diff_file" 2>/dev/null || true
     done < <(git ls-files --others --exclude-standard -z)
-
-    printf '%s\n__CMAI_SPLIT__\n%s' "$files" "$diffs"
 }
 
 # Function to save API key
@@ -683,16 +681,10 @@ CHANGES=$(git diff --name-status "${DIFF_ARGS[@]}" | tr '\t' ' ' | sed 's/  */ /
 git diff "${DIFF_ARGS[@]}" >"$DIFF_FILE" || fail "Failed to read git diff"
 
 if [ "$UNSTAGED" = true ]; then
-    UNTRACKED_DATA=$(get_untracked_changes)
-    UNTRACKED_CHANGES=${UNTRACKED_DATA%%$'\n'__CMAI_SPLIT__*}
-    UNTRACKED_DIFF=${UNTRACKED_DATA#*__CMAI_SPLIT__$'\n'}
+    UNTRACKED_CHANGES=$(get_untracked_changes "$DIFF_FILE")
 
     if [ -n "$UNTRACKED_CHANGES" ]; then
-        CHANGES="${CHANGES}${CHANGES:+$'\n'}${UNTRACKED_CHANGES%$'\n'}"
-    fi
-
-    if [ -n "$UNTRACKED_DIFF" ]; then
-        printf '\n%s' "${UNTRACKED_DIFF%$'\n'}" >>"$DIFF_FILE"
+        CHANGES="${CHANGES}${CHANGES:+$'\n'}${UNTRACKED_CHANGES}"
     fi
 fi
 

--- a/tests/git-commit-test.sh
+++ b/tests/git-commit-test.sh
@@ -186,4 +186,27 @@ if grep -Fq "jq: parse error" "$TEST_DIR/error"; then
     fail_test "raw jq parse error leaked to user"
 fi
 
+# Large untracked files must not be round-tripped through shell pattern matching:
+# quadratic matching made a 2MB file take >20 minutes. Guard with a hard timeout.
+(
+    cd "$TEST_DIR/repo" || exit 1
+    awk 'BEGIN { for (i = 0; i < 60000; i++) print "[CRITICAL] untracked noise line for unstaged diff" }' \
+        >untracked-large.log
+    printf 'small untracked file\n' >untracked-small.txt
+) || fail_test "failed to create untracked fixtures"
+
+export FAKE_HTTP_STATUS=200
+export FAKE_RESPONSE_BODY='{"error":false,"choices":[{"message":{"content":"chore(logs): add untracked logs"}}]}'
+if ! (
+    cd "$TEST_DIR/repo" || exit 1
+    timeout 60 "$SCRIPT" --message-only --unstaged
+) >"$TEST_DIR/output" 2>"$TEST_DIR/error"; then
+    fail_test "unstaged run with large untracked file failed or timed out"
+fi
+[ "$(cat "$TEST_DIR/output")" = "chore(logs): add untracked logs" ] ||
+    fail_test "generated message was not returned for unstaged run"
+assert_contains "$TEST_DIR/state/prompt" "A untracked-large.log"
+assert_contains "$TEST_DIR/state/prompt" "A untracked-small.txt"
+assert_contains "$TEST_DIR/state/prompt" "[Diff truncated to "
+
 echo "PASS: git-commit tests"


### PR DESCRIPTION
Refactor `get_untracked_changes` to append large diffs directly to a file
instead of concatenating them into shell strings. This prevents quadratic
pattern matching performance issues when handling large untracked files,
which previously caused timeouts. Add a regression test to ensure the
process completes within a reasonable time limit.